### PR TITLE
Deploy to GitHub pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Aid-Pioneers/developers

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     env:
@@ -47,3 +47,30 @@ jobs:
         run: |
           supabase link --project-ref $PRODUCTION_PROJECT_ID
           supabase db push
+
+      - name: Upload Artifacts
+        uses: actions/upload-pages-artifact@v1.0.9
+        with:
+          path: "build/"
+          retention-days: 7
+
+  deploy:
+
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2.0.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Shipment Aid Tracker
-
+[![CI](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/ci.yml)
+[![Deploy](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/deploy.yaml/badge.svg)](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/deploy.yaml)
 A web-app that facilitates the tracking of aid shipments around the world!
 
 Built as a React frontend backed by Supabase. Supabase is an open source Firebase alternative for building secure and performant Postgres backends with minimal configuration. Read more about it at https://supabase.com/docs/guides/getting-started.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CI and deployments are handled via GitHub actions.
 
 For CI, we verify that the types are up-to-date against the production schema.
 
-On deployment we ensure that all database migrations are run against the production schema. The Heroku project will then deploy the app at https://shipment-aid-tracker.herokuapp.com/.
+On deployment we run all database migrations against the production database and deploy our application to github pages: https://aid-pioneers.github.io/shipment-aid-tracker/.
 ## Quick Start
 To get up and running quickly follow the steps below 👇
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shipment-aid-tracker",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://aid-pioneers.github.io/shipment-aid-tracker/",
   "dependencies": {
     "@supabase/supabase-js": "^2.0",
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
### Changes / highlights
- 🚢  On updates to the `main` branch, deploy the site straight to Github pages : https://aid-pioneers.github.io/shipment-aid-tracker/.
- 🔗  Specify the `homepage` in `package.json` as otherwise all relative URLs will be at the domain level (e.g. `https://aid-pioneers.github.io/favicon.ico` instead of `https://aid-pioneers.github.io/shipment-aid-tracker/favicon.ico`, which is what we want).
- 📛 Add a badge to the `README` for CI and Deployment actions - these automatically hook into the events that GitHub action runs produce.

### Motivation
It keeps CI/CD simple by using a single platform (GitHub) to build, test, and deploy the service as opposed to Heroku, which is a little less accessible and just another moving part to consider.

### Approach
I've opted not to follow the [CRA instructions](https://create-react-app.dev/docs/deployment/#github-pages) exactly for a couple of reasons:
1. We can deploy this using 100% official GH actions rather than relying on custom GH actions from third parties (e.g. `npm gh-pages`) so perhaps the instructions above are out-of-date?
2. It seems that CRA is no longer actively maintained or supported, and so we probably don't want to lock ourselves into CRA esoterica/approaches where we don't need to.