### PR TITLE
Enable row-level security (RLS) on all tables and add policies for each that require authenticated users.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,7 @@ const App: React.FC = () => {
   */
   const supabaseUrl = 'http://localhost:54321';
   const supabaseKey =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF6cm5odHpycnBzbHN3Y3h5dW5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODMxMzY2ODgsImV4cCI6MTk5ODcxMjY4OH0.mdozM_3ZCFL2C5UOB35j7cjjxtWEoT6hT6ITS_BZjv8';
   const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
   const projects = getProjects(supabase);

--- a/supabase/migrations/20230702200334_enable_row_level_security_on_all_tables.sql
+++ b/supabase/migrations/20230702200334_enable_row_level_security_on_all_tables.sql
@@ -1,0 +1,30 @@
+alter table "public"."pallet" enable row level security;
+
+alter table "public"."pallet_scan" enable row level security;
+
+alter table "public"."project" enable row level security;
+
+alter table "public"."shipment" enable row level security;
+
+create policy "Enable read access for authenticated users."
+on "public"."pallet"
+as permissive
+for select
+to authenticated
+using (true);
+
+
+create policy "Enable read access for all users."
+on "public"."project"
+as permissive
+for select
+to public
+using (true);
+
+
+create policy "Enable read access for authenticated users."
+on "public"."shipment"
+as permissive
+for select
+to authenticated
+using (true);


### PR DESCRIPTION
**Note: for now the projects table is publicly readable but everything else requires an authenticated user.**

We don't currently have any data in these tables, so the main thing we want to secure against is unauthorised _writes_.

Once we have auth set up (and potentially some different roles) we can expand these policies and make them more specific/restrictive. For now, leaving `projects` as public will allow us to develop against the supabase data without having login/auth sorted (but coming soon!).