### PR TITLE
Rotate secrets used after exposing `service_role` secret.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shipment Aid Tracker
 [![CI](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/ci.yml/badge.svg)](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/ci.yml)
 [![Deploy](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/deploy.yaml/badge.svg)](https://github.com/Aid-Pioneers/shipment-aid-tracker/actions/workflows/deploy.yaml)
+
 A web-app that facilitates the tracking of aid shipments around the world!
 
 Built as a React frontend backed by Supabase. Supabase is an open source Firebase alternative for building secure and performant Postgres backends with minimal configuration. Read more about it at https://supabase.com/docs/guides/getting-started.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,7 +90,7 @@ const App: React.FC = () => {
   */
   const supabaseUrl = 'http://localhost:54321';
   const supabaseKey =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF6cm5odHpycnBzbHN3Y3h5dW5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODMxMzY2ODgsImV4cCI6MTk5ODcxMjY4OH0.mdozM_3ZCFL2C5UOB35j7cjjxtWEoT6hT6ITS_BZjv8';
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF6cm5odHpycnBzbHN3Y3h5dW5kIiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODgzNzE0NTUsImV4cCI6MjAwMzk0NzQ1NX0.CF2A2Lxnmb3crRemcVzyOsqpaLsRkVHZKyM0tPAuJLw';
   const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
   const projects = getProjects(supabase);


### PR DESCRIPTION
### Changes
- Rotate the API keys we are using to auth against supabase.

### Background

There are two keys that get generated for us automatically by supabase:

- `anon` key
- `service_role` key.

From the docs at https://supabase.com/docs/guides/api/api-keys

> The anon key has very few privileges. You can use it in your [RLS policies](https://supabase.com/docs/guides/auth/row-level-security) for "anonymous" access. For example, this policy will allow access to the profiles table.

whereas the

> The "service_role" is a predefined Postgres role with elevated privileges, designed to perform various administrative and service-related tasks. It can bypass Row Level Security, so it should only be used on a private server.

When setting up the service originally I erroneously committed the `service_role ` key, when I should've used the `anon` key. By going into the settings and refreshing the JWT key, it regenerates both keys for you. I've done this, but we now need to update the reference in the code to match.

<img width="1234" alt="image" src="https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/b5800f87-642b-43c1-a3ff-f6948c07983d">
