### PR TITLE
Ensure that only authenticated users can view projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ For example, to generate TypeScript types for all of the tables in the productio
 
 this is also possible to run against your local DB.
 
+## Troubleshooting
+
+### Registering and signing in locally
+Email confirmation can be enabled/disabled for local development by updating the local [supabase config]
+(./supabase/config.toml).
+
+If enabled, then any confirmation emails will be routed to a locally running [InBucket](http://localhost:54324/) and
+can be responded to there. Supabase will not send an email to an actual email server e.g. gmail!
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -56,7 +56,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin`, `notion`, `twitch`,

--- a/supabase/migrations/20230804170611_tighten_projects_rls_policy.sql
+++ b/supabase/migrations/20230804170611_tighten_projects_rls_policy.sql
@@ -1,0 +1,8 @@
+drop policy "Enable read access for all users." on "public"."project";
+
+create policy "Enable insert for authenticated users only"
+on "public"."project"
+as permissive
+for select
+to authenticated
+using (true);


### PR DESCRIPTION
### Background
Currently when you visit [aid-pioneers.github.io/shipment-aid-tracker/](https://aid-pioneers.github.io/shipment-aid-tracker/), you can see that we get a `console.log` of some projects. These are projects that exist in the production database.

You may note that at this point you are entirely unauthenticated. This works because there is currently no row-level security on the `projects` table, so anyone can query it.

<img width="1474" alt="image" src="https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/b98cc3a2-8f1d-48bf-99d8-c0290c19738c">

You can go to our supabase production project page and look at the [auth policies](https://supabase.com/dashboard/project/azrnhtzrrpslswcxyund/auth/policies) yourself.

### Changes
We don't want our tables to be open. So this PR updates the RLS for the `projects` table to ensure that only authenticated users can access it. In the future we can perform additional checks such as "if this user is an admin" or "if this user is a contributor to the project" etc.

### Try it out!
Now that we have a way to register a user and login, you will notice that the `console.log` returns an empty `[]` (as that is what we fallback to if the call to fetch projects fails). If you then register or sign-in and refresh the page, you will notice that you once again get the projects back. Voila.