### PR TITLE
Add overview page that lists projects and add sign-out option in footer.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,32 +7,17 @@ import { LoginContainer } from './containers/login';
 import { RegistrationContainer } from './containers/registration';
 import { ProjectOverview } from './containers/project-overview';
 
-async function getProjects(supabase: SupabaseClient<Database>) {
-  const { data, error } = await supabase.from('project').select('*');
-
-  if (error) {
-    console.error('Found an issue fetching projects.', error);
-    return Promise.resolve([]);
-  }
-
-  return data;
-}
-
 const App: React.FC = () => {
-  const supabase = createClient<Database>(supabaseUrl, supabaseKey);
-
-  const projects = getProjects(supabase);
-
-  projects.then(console.log);
+  const supabase: SupabaseClient = createClient<Database>(supabaseUrl, supabaseKey);
 
   return (
     <>
       <HashRouter basename = "/">
         <Routes>
-          <Route path="/" element={<LoginContainer supabase={supabase} />} />
+          <Route path="/" element={<ProjectOverview supabase={supabase} />} />
+          <Route path="/overview" element={<ProjectOverview supabase={supabase}/>} />
           <Route path="/login" element={<LoginContainer supabase={supabase} />} />
           <Route path="/register" element={<RegistrationContainer supabase={supabase} />} />
-          <Route path="/overview" element={<ProjectOverview />} />
         </Routes>
       </HashRouter>
     </>

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
-export const Footer: React.FC = () => {
-  return <>{/* TODO add  footer component code here */}</>;
-};
+interface FooterProps {
+  onSignOut: () => void;
+}
+
+export const Footer: React.FC<FooterProps> = ({ onSignOut }) =>
+  <p onClick={onSignOut}>
+    Sign out
+  </p>

--- a/src/components/project/card/index.tsx
+++ b/src/components/project/card/index.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
-import { Database } from '../../../database.types';
+import { DbProject } from '../../../types/aliases';
 
-type Project = Database['public']['Tables']['project']['Row']
-
-export const ProjectCard: React.FC<{ project: Project }> = ({
-  project,
-}) => {
-
+export const ProjectCard: React.FC<{ project: DbProject }> = ({ project }) => {
   return (
     <div className="col-12 col-md-6 col-xl-4">
-        <div className="project-cards-container project-card-text-not-bootstrap">
-          <h4>{project.name}</h4>
-          <p>Created on {new Date(Date.parse(project.created_at)).toLocaleDateString()}</p>
-        </div>
+      <div className="project-cards-container project-card-text-not-bootstrap">
+        <h4>{project.name}</h4>
+        <p>
+          Created on{' '}
+          {new Date(Date.parse(project.created_at)).toLocaleDateString()}
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/components/project/card/index.tsx
+++ b/src/components/project/card/index.tsx
@@ -1,34 +1,18 @@
 import React from 'react';
+import { Database } from '../../../database.types';
 
-export const ProjectCard: React.FC<{ project: { name: string } }> = ({
+type Project = Database['public']['Tables']['project']['Row']
+
+export const ProjectCard: React.FC<{ project: Project }> = ({
   project,
 }) => {
-  // tODO update this
-  function shipmentsPath(): string | undefined {
-    throw new Error('Function not implemented.');
-  }
 
   return (
     <div className="col-12 col-md-6 col-xl-4">
-      <a href={shipmentsPath()}>
-        {['Northern Iraq', 'Sierra Leone', 'Syria', 'Ukraine'].includes(
-          project.name
-        ) ? (
-          <div
-            className="project-card"
-            style={{
-              backgroundImage: `url(${require(`./${project.name}.jpg`)})`,
-            }}
-          ></div>
-        ) : (
-          <div className="project-card"></div>
-        )}
         <div className="project-cards-container project-card-text-not-bootstrap">
-          <h4>
-            <b>{project.name}</b>
-          </h4>
+          <h4>{project.name}</h4>
+          <p>Created on {new Date(Date.parse(project.created_at)).toLocaleDateString()}</p>
         </div>
-      </a>
     </div>
   );
 };

--- a/src/components/project/list/index.tsx
+++ b/src/components/project/list/index.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { Database } from '../../../database.types';
 import { ProjectCard } from '../card';
 
-export const ProjectsList: React.FC<{ projects: { name: string }[] }> = ({
+type Project = Database['public']['Tables']['project']['Row']
+
+export const ProjectsList: React.FC<{ projects: Project[] }> = ({
   projects,
 }) => {
   return (

--- a/src/components/project/list/index.tsx
+++ b/src/components/project/list/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Database } from '../../../database.types';
 import { ProjectCard } from '../card';
+import { DbProject } from '../../../types/aliases';
 
-type Project = Database['public']['Tables']['project']['Row']
-
-export const ProjectsList: React.FC<{ projects: Project[] }> = ({
+export const ProjectsList: React.FC<{ projects: DbProject[] }> = ({
   projects,
 }) => {
   return (

--- a/src/containers/login/index.tsx
+++ b/src/containers/login/index.tsx
@@ -2,20 +2,27 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import LoginForm, { LoginFormData } from '../../components/login';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Database } from '../../database.types';
-
+import { useNavigate } from 'react-router-dom';
 
 interface LoginContainerProps {
-  supabase: SupabaseClient<Database>;
+  supabase: SupabaseClient;
 }
 
 export const LoginContainer: React.FC<LoginContainerProps> = ({supabase}) => {
-  const handleLoginFormSubmit = (data: LoginFormData) => {
-    supabase.auth.signInWithPassword({
+
+  const navigate = useNavigate();
+
+  async function handleLoginFormSubmit(data: LoginFormData) {
+    const {error} = await supabase.auth.signInWithPassword({
       email: data.email,
       password: data.password
-    })
-  };
+    });
+
+    if (error)
+      console.warn('Encountered an error when logging in.', error.cause);
+    else
+      return navigate("/overview")
+    };
 
   return (
     <div>

--- a/src/containers/project-overview/index.tsx
+++ b/src/containers/project-overview/index.tsx
@@ -5,54 +5,56 @@ import { ProjectsList } from '../../components/project/list';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { Database } from '../../database.types';
 import { useNavigate } from 'react-router-dom';
+import { DbProject } from '../../types/aliases';
 
 interface ProjectOverviewContainerProps {
   supabase: SupabaseClient<Database>;
 }
 
-type Project = Database['public']['Tables']['project']['Row']
-
-export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({ supabase }) => {
-
+export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({
+  supabase,
+}) => {
   const navigate = useNavigate();
 
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<DbProject[]>([]);
   const [errors, setErrors] = useState<String[]>([]);
 
   async function handleSignOut() {
-
     let { error } = await supabase.auth.getSession();
     if (error)
-      console.warn('Encountered an error whilst fetching user session.', error.cause);
+      console.warn(
+        'Encountered an error whilst fetching user session.',
+        error.cause
+      );
     else {
       let { error } = await supabase.auth.signOut();
       if (error)
-        console.warn('Encountered an error whilst signing out.', error.cause)
+        console.warn('Encountered an error whilst signing out.', error.cause);
 
-      return navigate("/login");
-    };
+      return navigate('/login');
+    }
   }
 
   useEffect(() => {
-
     async function loadProjects() {
       const { data, error } = await supabase.from('project').select('*');
 
-      if (data)
-        setProjects(data);
-      else
-        setErrors([error.message]);
+      if (data) setProjects(data);
+      else setErrors([error.message]);
     }
 
-    loadProjects()
-
+    loadProjects();
   }, []);
 
   return (
     <>
       <Banner />
-      {errors ? errors.map(error => <p>{error}</p>) : <ProjectsList projects={projects} />}
-      <Footer onSignOut={handleSignOut}/>
+      {errors ? (
+        errors.map((error) => <p>{error}</p>)
+      ) : (
+        <ProjectsList projects={projects} />
+      )}
+      <Footer onSignOut={handleSignOut} />
     </>
   );
 };

--- a/src/containers/project-overview/index.tsx
+++ b/src/containers/project-overview/index.tsx
@@ -1,20 +1,59 @@
+import { useEffect, useState } from 'react';
 import { Banner } from '../../components/banner';
 import { Footer } from '../../components/footer';
 import { ProjectsList } from '../../components/project/list';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { Database } from '../../database.types';
+import { useNavigate } from 'react-router-dom';
 
-export const ProjectOverview = () => {
+interface ProjectOverviewContainerProps {
+  supabase: SupabaseClient<Database>;
+}
+
+type Project = Database['public']['Tables']['project']['Row']
+
+export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({ supabase }) => {
+
+  const navigate = useNavigate();
+
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [errors, setErrors] = useState<String[]>([]);
+
+  async function handleSignOut() {
+
+    let { error } = await supabase.auth.getSession();
+    if (error)
+      console.warn('Encountered an error whilst fetching user session.', error.cause);
+    else {
+      let { error } = await supabase.auth.signOut();
+      if (error)
+        console.warn('Encountered an error whilst signing out.', error.cause)
+
+      console.log("Okay redirecting to /login...")
+      return navigate("/login");
+    };
+  }
+
+  useEffect(() => {
+
+    async function loadProjects() {
+      const { data, error } = await supabase.from('project').select('*');
+
+      if (data)
+        setProjects(data);
+      else
+        setErrors([error.message]);
+    }
+
+    loadProjects()
+
+  }, []);
+
   return (
     <>
       <Banner />
-      <ProjectsList
-        projects={[
-          { name: 'sierra leone' },
-          { name: 'lebanon' },
-          { name: 'ukraine' },
-          { name: 'turkey' },
-        ]}
-      />
-      <Footer />
+      {errors ? errors.map(error => <p>{error}</p>) : <ProjectsList projects={projects} />}
+      <Footer onSignOut={handleSignOut}/>
     </>
   );
 };

--- a/src/containers/project-overview/index.tsx
+++ b/src/containers/project-overview/index.tsx
@@ -28,9 +28,9 @@ export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({
       );
     else {
       let { error } = await supabase.auth.signOut();
-      if (error)
+      if (error) {
         console.warn('Encountered an error whilst signing out.', error.cause);
-
+      }
       return navigate('/login');
     }
   }
@@ -39,8 +39,8 @@ export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({
     async function loadProjects() {
       const { data, error } = await supabase.from('project').select('*');
 
-      if (data) setProjects(data);
-      else setErrors([error.message]);
+      if (error) setErrors([error.message]);
+      else setProjects(data);
     }
 
     loadProjects();
@@ -50,6 +50,7 @@ export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({
     <>
       <Banner />
       {errors ? (
+        // TODO #15 make an error component and pass error in as props
         errors.map((error) => <p>{error}</p>)
       ) : (
         <ProjectsList projects={projects} />

--- a/src/containers/project-overview/index.tsx
+++ b/src/containers/project-overview/index.tsx
@@ -29,7 +29,6 @@ export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({ supab
       if (error)
         console.warn('Encountered an error whilst signing out.', error.cause)
 
-      console.log("Okay redirecting to /login...")
       return navigate("/login");
     };
   }

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -1,0 +1,3 @@
+import { Database } from "../database.types";
+
+export type DbProject = Database['public']['Tables']['project']['Row']


### PR DESCRIPTION
We now have the following pages 👇 

When you log in, you get redirected to the overview page. When you sign out (currently only available from the overview page 🙃 ) then you get redirected to the login page.

Note: we should probably decide on "sign in" and "sign out" vs "log in" and "log out" 😅 

`/#/overview` (logged out)
<img width="486" alt="image" src="https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/0a941e21-ca0d-45ee-9b36-e43d48b03893">

`/#/overview` (logged in)
<img width="476" alt="image" src="https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/235c95a3-9f46-4236-bcca-3d89c0bbfb75">

`/#/login`
<img width="379" alt="image" src="https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/26ef8b9c-8200-454e-bf91-43f601a9331a">

`/#/register`
<img width="414" alt="image" src="https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/a15299e4-4408-492c-a7f6-f1923783e567">

