### PR TITLE
fix: Ensure that linting errors that would prevent a deployment also surface in CI run.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run tests
         run: npm test -- --watchAll=false
 
+      - name: Build app
+        run: npm run build
+
   verify-supabase-types:
     runs-on: ubuntu-latest
 

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 interface FooterProps {
   onSignOut: () => void;

--- a/src/containers/project-overview/index.tsx
+++ b/src/containers/project-overview/index.tsx
@@ -38,6 +38,7 @@ export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({ supab
     }
 
     loadProjects();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/containers/project-overview/index.tsx
+++ b/src/containers/project-overview/index.tsx
@@ -38,8 +38,7 @@ export const ProjectOverview: React.FC<ProjectOverviewContainerProps> = ({ supab
     }
 
     loadProjects();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [supabase]);
 
   return (
     <>


### PR DESCRIPTION
Ideally we could just run `npx eslint` and it would pump out the same warnings as errors, but when I try running this I get way more errors than we see on the build. Presumably this is because `npm run build` causes `react-scripts` to run `eslint` with loads of config and exclusions (e.g. tests).

Instead of trying to track down what it is doing, we may as well just test that it can be built successfully.