### PR TITLE
Feat 42: Add more DB data into the shipment creation form.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { SignUpContainer } from './containers/sign-up';
 import { AuthService } from './services/auth-service';
 import { ConsigneeService } from './services/consignee-service';
 import { CountryService } from './services/country-service';
+import { DonorService } from './services/donor-service';
 import { ProjectService } from './services/project-service';
 import { ShipmentService } from './services/shipment-service';
 import { Database } from './types/database.types';
@@ -22,6 +23,7 @@ const App: React.FC = () => {
   const shipmentService: ShipmentService = new ShipmentService(supabase);
   const countryService: CountryService = new CountryService(supabase);
   const consigneeService: ConsigneeService = new ConsigneeService(supabase);
+  const donorService: DonorService = new DonorService(supabase);
 
   return (
     <ChakraProvider>
@@ -32,7 +34,7 @@ const App: React.FC = () => {
           <Route path="/sign-in" element={<SignInContainer authService={authService} />} />
           <Route path="/sign-up" element={<SignUpContainer authService={authService} />} />
           <Route path="/shipments" element={<ShipmentOverview shipmentService={shipmentService} />} />
-          <Route path="/shipments/new" element={<ShipmentCreationContainer shipmentService={shipmentService} countryService={countryService} consigneeService={consigneeService} />} />
+          <Route path="/shipments/new" element={<ShipmentCreationContainer shipmentService={shipmentService} countryService={countryService} consigneeService={consigneeService} donorService={donorService} />} />
         </Routes>
       </HashRouter>
     </ChakraProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,25 @@
+import { ChakraProvider } from '@chakra-ui/react';
+import { SupabaseClient, createClient } from '@supabase/supabase-js';
 import React from 'react';
 import { HashRouter, Route, Routes } from 'react-router-dom';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { Database } from './types/database.types';
 import { supabaseKey, supabaseUrl } from './config/config';
+import { ProjectOverview } from './containers/project-overview';
+import { ShipmentCreationContainer } from './containers/shipment/shipment-creation';
+import { ShipmentOverview } from './containers/shipment/shipment-list-view';
 import { SignInContainer } from './containers/sign-in';
 import { SignUpContainer } from './containers/sign-up';
-import { ProjectOverview } from './containers/project-overview';
 import { AuthService } from './services/auth-service';
+import { CountryService } from './services/country-service';
 import { ProjectService } from './services/project-service';
 import { ShipmentService } from './services/shipment-service';
-import { ShipmentOverview } from './containers/shipment/shipment-list-view';
-import { ShipmentCreationContainer } from './containers/shipment/shipment-creation';
-import { ChakraProvider } from '@chakra-ui/react';
+import { Database } from './types/database.types';
 
 const App: React.FC = () => {
   const supabase: SupabaseClient = createClient<Database>(supabaseUrl, supabaseKey);
   const authService: AuthService = new AuthService(supabase);
   const projectService: ProjectService = new ProjectService(supabase);
   const shipmentService: ShipmentService = new ShipmentService(supabase);
+  const countryService: CountryService = new CountryService(supabase);
 
   return (
     <ChakraProvider>
@@ -28,7 +30,7 @@ const App: React.FC = () => {
           <Route path="/sign-in" element={<SignInContainer authService={authService} />} />
           <Route path="/sign-up" element={<SignUpContainer authService={authService} />} />
           <Route path="/shipments" element={<ShipmentOverview shipmentService={shipmentService} />} />
-          <Route path="/shipments/new" element={<ShipmentCreationContainer shipmentService={shipmentService} />} />
+          <Route path="/shipments/new" element={<ShipmentCreationContainer shipmentService={shipmentService} countryService={countryService} />} />
         </Routes>
       </HashRouter>
     </ChakraProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ShipmentOverview } from './containers/shipment/shipment-list-view';
 import { SignInContainer } from './containers/sign-in';
 import { SignUpContainer } from './containers/sign-up';
 import { AuthService } from './services/auth-service';
+import { ConsigneeService } from './services/consignee-service';
 import { CountryService } from './services/country-service';
 import { ProjectService } from './services/project-service';
 import { ShipmentService } from './services/shipment-service';
@@ -20,6 +21,7 @@ const App: React.FC = () => {
   const projectService: ProjectService = new ProjectService(supabase);
   const shipmentService: ShipmentService = new ShipmentService(supabase);
   const countryService: CountryService = new CountryService(supabase);
+  const consigneeService: ConsigneeService = new ConsigneeService(supabase);
 
   return (
     <ChakraProvider>
@@ -30,7 +32,7 @@ const App: React.FC = () => {
           <Route path="/sign-in" element={<SignInContainer authService={authService} />} />
           <Route path="/sign-up" element={<SignUpContainer authService={authService} />} />
           <Route path="/shipments" element={<ShipmentOverview shipmentService={shipmentService} />} />
-          <Route path="/shipments/new" element={<ShipmentCreationContainer shipmentService={shipmentService} countryService={countryService} />} />
+          <Route path="/shipments/new" element={<ShipmentCreationContainer shipmentService={shipmentService} countryService={countryService} consigneeService={consigneeService} />} />
         </Routes>
       </HashRouter>
     </ChakraProvider>

--- a/src/components/shipment/creation/general/index.tsx
+++ b/src/components/shipment/creation/general/index.tsx
@@ -3,16 +3,17 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormWrapper } from '../../../../containers/shipment/shipment-creation/index.styles';
-import { DbCountry, DbShipmentType } from '../../../../types/aliases';
+import { DbConsignee, DbCountry, DbShipmentType } from '../../../../types/aliases';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
 
 interface GeneralComponentProps {
   startCollapsed?: boolean,
   countries: DbCountry[],
-  shipmentTypes: DbShipmentType[]
+  shipmentTypes: DbShipmentType[],
+  consignees: DbConsignee[]
 }
 
-export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries, shipmentTypes }) => {
+export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries, shipmentTypes, consignees }) => {
 
   const { handleSubmit } = useForm<FormData>();
 
@@ -23,6 +24,8 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
   const countryOptions = countries.map(country => <option value={country.id} key={country.id}>{country.name}</option>)
 
   const shipmentTypeOptions = shipmentTypes.map(shipmentType => <option value={shipmentType.id} key={shipmentType.id}>{shipmentType.shipment_type}</option>)
+
+  const consigneeOptions = consignees.map(consignee => <option value={consignee.id} key={consignee.id}>{consignee.name}</option>)
 
   return (
     <FormWrapper>
@@ -50,9 +53,8 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
             </GridItem>
             <GridItem colSpan={[6, 4]}>
               <label>Consignee (recipient)</label>
-              {/* TODO this list should be fetched from database */}
               <Select placeholder="Select option">
-                <option value="uhu">UHU / P22</option>
+                {consigneeOptions}
               </Select>
             </GridItem>
             <GridItem colSpan={[6, 4]}>

--- a/src/components/shipment/creation/general/index.tsx
+++ b/src/components/shipment/creation/general/index.tsx
@@ -3,17 +3,18 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormWrapper } from '../../../../containers/shipment/shipment-creation/index.styles';
-import { DbConsignee, DbCountry, DbShipmentType } from '../../../../types/aliases';
+import { DbConsignee, DbCountry, DbShipmentStatus, DbShipmentType } from '../../../../types/aliases';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
 
 interface GeneralComponentProps {
   startCollapsed?: boolean,
   countries: DbCountry[],
   shipmentTypes: DbShipmentType[],
+  shipmentStatuses: DbShipmentStatus[],
   consignees: DbConsignee[]
 }
 
-export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries, shipmentTypes, consignees }) => {
+export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries, shipmentTypes, shipmentStatuses, consignees }) => {
 
   const { handleSubmit } = useForm<FormData>();
 
@@ -24,6 +25,8 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
   const countryOptions = countries.map(country => <option value={country.id} key={country.id}>{country.name}</option>)
 
   const shipmentTypeOptions = shipmentTypes.map(shipmentType => <option value={shipmentType.id} key={shipmentType.id}>{shipmentType.shipment_type}</option>)
+
+  const shipmentStatusOptions = shipmentStatuses.map(shipmentStatus => <option value={shipmentStatus.id} key={shipmentStatus.id}>{shipmentStatus.status}</option>)
 
   const consigneeOptions = consignees.map(consignee => <option value={consignee.id} key={consignee.id}>{consignee.name}</option>)
 
@@ -80,10 +83,7 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
             <GridItem colSpan={[6, 4]}>
               <label>Status</label>
               <Select placeholder="Select option">
-                <option value="planned">Planned</option>
-                <option value="confirmed">Confirmed</option>
-                <option value="shipped">Shipped</option>
-                <option value="delivered">Delivered</option>
+                {shipmentStatusOptions}
               </Select>
             </GridItem>
           </Grid>

--- a/src/components/shipment/creation/general/index.tsx
+++ b/src/components/shipment/creation/general/index.tsx
@@ -3,19 +3,23 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormWrapper } from '../../../../containers/shipment/shipment-creation/index.styles';
+import { DbCountry } from '../../../../types/aliases';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
 
 interface GeneralComponentProps {
-  startCollapsed?: boolean
+  startCollapsed?: boolean,
+  countries: DbCountry[]
 }
 
-export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed }) => {
+export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries }) => {
 
   const { handleSubmit } = useForm<FormData>();
 
   const [isCollapsed, setCollapsed] = useState<boolean | undefined>(startCollapsed);
 
-  const onSubmit = () => { };
+
+  const countryOptions = countries.map(country => <option value={country.id}>{country.name}</option>)
+
 
   return (
     <FormWrapper>
@@ -26,15 +30,13 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
             <GridItem colSpan={[6, 4]}>
               <label>Origin</label>
               <Select placeholder="Select origin">
-                {/* TODO this list should be fetched from database */}
-                <option value="ukraine">New York, USA</option>
+                {countryOptions}
               </Select>
             </GridItem>
             <GridItem colSpan={[6, 4]}>
               <label>Destination</label>
               <Select placeholder="Select origin">
-                {/* TODO this list should be fetched from database */}
-                <option value="ukraine">Kyiv, Ukraine</option>
+                {countryOptions}
               </Select>
             </GridItem>
             <GridItem colSpan={[6, 4]}>

--- a/src/components/shipment/creation/general/index.tsx
+++ b/src/components/shipment/creation/general/index.tsx
@@ -3,23 +3,26 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormWrapper } from '../../../../containers/shipment/shipment-creation/index.styles';
-import { DbCountry } from '../../../../types/aliases';
+import { DbCountry, DbShipmentType } from '../../../../types/aliases';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
 
 interface GeneralComponentProps {
   startCollapsed?: boolean,
-  countries: DbCountry[]
+  countries: DbCountry[],
+  shipmentTypes: DbShipmentType[]
 }
 
-export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries }) => {
+export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({ startCollapsed, countries, shipmentTypes }) => {
 
   const { handleSubmit } = useForm<FormData>();
 
   const [isCollapsed, setCollapsed] = useState<boolean | undefined>(startCollapsed);
 
+  const onSubmit = (data: any) => { };
 
-  const countryOptions = countries.map(country => <option value={country.id}>{country.name}</option>)
+  const countryOptions = countries.map(country => <option value={country.id} key={country.id}>{country.name}</option>)
 
+  const shipmentTypeOptions = shipmentTypes.map(shipmentType => <option value={shipmentType.id} key={shipmentType.id}>{shipmentType.shipment_type}</option>)
 
   return (
     <FormWrapper>
@@ -42,11 +45,7 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
             <GridItem colSpan={[6, 4]}>
               <label>Main shipment type</label>
               <Select placeholder="Select option">
-                {/* TODO this list should be fetched from database */}
-                <option value="shipping">Shipping</option>
-                <option value="air_freight">Air Freight</option>
-                <option value="trains">Trains</option>
-                <option value="trucks">Trucks</option>
+                {shipmentTypeOptions}
               </Select>
             </GridItem>
             <GridItem colSpan={[6, 4]}>

--- a/src/components/shipment/creation/packing-list/index.tsx
+++ b/src/components/shipment/creation/packing-list/index.tsx
@@ -3,16 +3,20 @@ import * as React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormWrapper } from '../../../../containers/shipment/shipment-creation/index.styles';
+import { DbDonor } from '../../../../types/aliases';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
 
 interface PackingListComponentProps {
-  startCollapsed?: boolean
+  startCollapsed?: boolean,
+  donors: DbDonor[]
 }
 
-export const ShipmentCreationPackingListComponent: React.FC<PackingListComponentProps> = ({ startCollapsed }) => {
+export const ShipmentCreationPackingListComponent: React.FC<PackingListComponentProps> = ({ startCollapsed, donors }) => {
   const { handleSubmit } = useForm<FormData>();
 
   const [isCollapsed, setCollapsed] = useState<boolean | undefined>(startCollapsed);
+
+  const donorOptions = donors.map(donor => <option value={donor.id} key={donor.id}>{donor.name}</option>)
 
   const onSubmit = () => { };
 
@@ -31,10 +35,9 @@ export const ShipmentCreationPackingListComponent: React.FC<PackingListComponent
               </Spacer>
             </GridItem>
             <GridItem colSpan={[4, 4]}>
-              {/* TODO this list should be fetched from database */}
               <label>Donor</label>
               <Select placeholder="Select option">
-                <option value="crowd-donation">CrowdDonation</option>
+                {donorOptions}
               </Select>
             </GridItem>
           </Grid>

--- a/src/containers/shipment/shipment-creation/index.tsx
+++ b/src/containers/shipment/shipment-creation/index.tsx
@@ -6,7 +6,7 @@ import { ShipmentCreationTrackingComponent } from '../../../components/shipment/
 import { ConsigneeService } from '../../../services/consignee-service';
 import { CountryService } from '../../../services/country-service';
 import { ShipmentService } from '../../../services/shipment-service';
-import { DbConsignee, DbCountry, DbShipmentType } from '../../../types/aliases';
+import { DbConsignee, DbCountry, DbShipmentStatus, DbShipmentType } from '../../../types/aliases';
 interface ShipmentCreationContainerProps {
   shipmentService: ShipmentService;
   countryService: CountryService;
@@ -17,6 +17,7 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
 
   const [countries, setCountries] = useState<DbCountry[]>([]);
   const [shipmentTypes, setShipmentTypes] = useState<DbShipmentType[]>([]);
+  const [shipmentStatuses, setShipmentStatuses] = useState<DbShipmentStatus[]>([]);
   const [consignees, setConsignees] = useState<DbConsignee[]>([]);
 
   useEffect(() => {
@@ -28,6 +29,10 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
         ),
         shipmentService.fetchShipmentTypes(
           (data) => setShipmentTypes(data),
+          (error) => console.error(error)
+        ),
+        shipmentService.fetchShipmentStatuses(
+          (data) => setShipmentStatuses(data),
           (error) => console.error(error)
         ),
         consigneeService.fetchConsignees(
@@ -45,7 +50,7 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
     <VStack>
       {/* TODO can we make this h1 left aligned? */}
       <Heading as="h1">Create a shipment</Heading>
-      <ShipmentCreationGeneralComponent countries={countries} shipmentTypes={shipmentTypes} consignees={consignees} />
+      <ShipmentCreationGeneralComponent countries={countries} shipmentTypes={shipmentTypes} shipmentStatuses={shipmentStatuses} consignees={consignees} />
       <ShipmentCreationPackingListComponent startCollapsed={false} />
       <ShipmentCreationTrackingComponent startCollapsed={true} />
       {/* TODO can we make this HStack left aligned? */}

--- a/src/containers/shipment/shipment-creation/index.tsx
+++ b/src/containers/shipment/shipment-creation/index.tsx
@@ -1,22 +1,37 @@
 import { Button, HStack, Heading, VStack } from '@chakra-ui/react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ShipmentCreationGeneralComponent } from '../../../components/shipment/creation/general';
 import { ShipmentCreationPackingListComponent } from '../../../components/shipment/creation/packing-list';
 import { ShipmentCreationTrackingComponent } from '../../../components/shipment/creation/tracking';
+import { CountryService } from '../../../services/country-service';
 import { ShipmentService } from '../../../services/shipment-service';
+import { DbCountry } from '../../../types/aliases';
 interface ShipmentCreationContainerProps {
   shipmentService: ShipmentService;
+  countryService: CountryService;
 }
 
-export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService }) => {
-  console.log({ shipmentService });
+export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService, countryService }) => {
+
+  const [countries, setCountries] = useState<DbCountry[]>([]);
+
+  useEffect(() => {
+    const loadData = async () => {
+      return countryService.fetchCountries(
+        (data) => setCountries(data),
+        (error) => console.error(error)
+      );
+    };
+    loadData();
+  }, [countryService]);
+
   // NB: this container will handle making API calls and passing props into
   // Create a React context with all the data from the API required to render the forms (donors, destinations, statuses etc)
   return (
     <VStack>
       {/* TODO can we make this h1 left aligned? */}
       <Heading as="h1">Create a shipment</Heading>
-      <ShipmentCreationGeneralComponent />
+      <ShipmentCreationGeneralComponent countries={countries} />
       <ShipmentCreationPackingListComponent startCollapsed={false} />
       <ShipmentCreationTrackingComponent startCollapsed={true} />
       {/* TODO can we make this HStack left aligned? */}

--- a/src/containers/shipment/shipment-creation/index.tsx
+++ b/src/containers/shipment/shipment-creation/index.tsx
@@ -5,7 +5,7 @@ import { ShipmentCreationPackingListComponent } from '../../../components/shipme
 import { ShipmentCreationTrackingComponent } from '../../../components/shipment/creation/tracking';
 import { CountryService } from '../../../services/country-service';
 import { ShipmentService } from '../../../services/shipment-service';
-import { DbCountry } from '../../../types/aliases';
+import { DbCountry, DbShipmentType } from '../../../types/aliases';
 interface ShipmentCreationContainerProps {
   shipmentService: ShipmentService;
   countryService: CountryService;
@@ -14,16 +14,22 @@ interface ShipmentCreationContainerProps {
 export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService, countryService }) => {
 
   const [countries, setCountries] = useState<DbCountry[]>([]);
+  const [shipmentTypes, setShipmentTypes] = useState<DbShipmentType[]>([]);
 
   useEffect(() => {
     const loadData = async () => {
-      return countryService.fetchCountries(
-        (data) => setCountries(data),
-        (error) => console.error(error)
-      );
+      return Promise.all([
+        countryService.fetchCountries(
+          (data) => setCountries(data),
+          (error) => console.error(error)
+        ),
+        shipmentService.fetchShipmentTypes(
+          (data) => setShipmentTypes(data),
+          (error) => console.error(error)
+        )]);
     };
     loadData();
-  }, [countryService]);
+  }, [shipmentService, countryService]);
 
   // NB: this container will handle making API calls and passing props into
   // Create a React context with all the data from the API required to render the forms (donors, destinations, statuses etc)
@@ -31,7 +37,7 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
     <VStack>
       {/* TODO can we make this h1 left aligned? */}
       <Heading as="h1">Create a shipment</Heading>
-      <ShipmentCreationGeneralComponent countries={countries} />
+      <ShipmentCreationGeneralComponent countries={countries} shipmentTypes={shipmentTypes} />
       <ShipmentCreationPackingListComponent startCollapsed={false} />
       <ShipmentCreationTrackingComponent startCollapsed={true} />
       {/* TODO can we make this HStack left aligned? */}

--- a/src/containers/shipment/shipment-creation/index.tsx
+++ b/src/containers/shipment/shipment-creation/index.tsx
@@ -5,20 +5,23 @@ import { ShipmentCreationPackingListComponent } from '../../../components/shipme
 import { ShipmentCreationTrackingComponent } from '../../../components/shipment/creation/tracking';
 import { ConsigneeService } from '../../../services/consignee-service';
 import { CountryService } from '../../../services/country-service';
+import { DonorService } from '../../../services/donor-service';
 import { ShipmentService } from '../../../services/shipment-service';
-import { DbConsignee, DbCountry, DbShipmentStatus, DbShipmentType } from '../../../types/aliases';
+import { DbConsignee, DbCountry, DbDonor, DbShipmentStatus, DbShipmentType } from '../../../types/aliases';
 interface ShipmentCreationContainerProps {
   shipmentService: ShipmentService;
   countryService: CountryService;
   consigneeService: ConsigneeService;
+  donorService: DonorService;
 }
 
-export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService, countryService, consigneeService }) => {
+export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService, countryService, consigneeService, donorService }) => {
 
   const [countries, setCountries] = useState<DbCountry[]>([]);
   const [shipmentTypes, setShipmentTypes] = useState<DbShipmentType[]>([]);
   const [shipmentStatuses, setShipmentStatuses] = useState<DbShipmentStatus[]>([]);
   const [consignees, setConsignees] = useState<DbConsignee[]>([]);
+  const [donors, setDonors] = useState<DbDonor[]>([]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -38,11 +41,15 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
         consigneeService.fetchConsignees(
           (data) => setConsignees(data),
           (error) => console.error(error)
+        ),
+        donorService.fetchDonors(
+          (data) => setDonors(data),
+          (error) => console.error(error)
         )
       ]);
     };
     loadData();
-  }, [shipmentService, countryService, consigneeService]);
+  }, [shipmentService, countryService, consigneeService, donorService]);
 
   // NB: this container will handle making API calls and passing props into
   // Create a React context with all the data from the API required to render the forms (donors, destinations, statuses etc)
@@ -51,7 +58,7 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
       {/* TODO can we make this h1 left aligned? */}
       <Heading as="h1">Create a shipment</Heading>
       <ShipmentCreationGeneralComponent countries={countries} shipmentTypes={shipmentTypes} shipmentStatuses={shipmentStatuses} consignees={consignees} />
-      <ShipmentCreationPackingListComponent startCollapsed={false} />
+      <ShipmentCreationPackingListComponent startCollapsed={false} donors={donors} />
       <ShipmentCreationTrackingComponent startCollapsed={true} />
       {/* TODO can we make this HStack left aligned? */}
       <HStack spacing={20} align="left">

--- a/src/containers/shipment/shipment-creation/index.tsx
+++ b/src/containers/shipment/shipment-creation/index.tsx
@@ -3,18 +3,21 @@ import React, { useEffect, useState } from 'react';
 import { ShipmentCreationGeneralComponent } from '../../../components/shipment/creation/general';
 import { ShipmentCreationPackingListComponent } from '../../../components/shipment/creation/packing-list';
 import { ShipmentCreationTrackingComponent } from '../../../components/shipment/creation/tracking';
+import { ConsigneeService } from '../../../services/consignee-service';
 import { CountryService } from '../../../services/country-service';
 import { ShipmentService } from '../../../services/shipment-service';
-import { DbCountry, DbShipmentType } from '../../../types/aliases';
+import { DbConsignee, DbCountry, DbShipmentType } from '../../../types/aliases';
 interface ShipmentCreationContainerProps {
   shipmentService: ShipmentService;
   countryService: CountryService;
+  consigneeService: ConsigneeService;
 }
 
-export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService, countryService }) => {
+export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps> = ({ shipmentService, countryService, consigneeService }) => {
 
   const [countries, setCountries] = useState<DbCountry[]>([]);
   const [shipmentTypes, setShipmentTypes] = useState<DbShipmentType[]>([]);
+  const [consignees, setConsignees] = useState<DbConsignee[]>([]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -26,10 +29,15 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
         shipmentService.fetchShipmentTypes(
           (data) => setShipmentTypes(data),
           (error) => console.error(error)
-        )]);
+        ),
+        consigneeService.fetchConsignees(
+          (data) => setConsignees(data),
+          (error) => console.error(error)
+        )
+      ]);
     };
     loadData();
-  }, [shipmentService, countryService]);
+  }, [shipmentService, countryService, consigneeService]);
 
   // NB: this container will handle making API calls and passing props into
   // Create a React context with all the data from the API required to render the forms (donors, destinations, statuses etc)
@@ -37,7 +45,7 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
     <VStack>
       {/* TODO can we make this h1 left aligned? */}
       <Heading as="h1">Create a shipment</Heading>
-      <ShipmentCreationGeneralComponent countries={countries} shipmentTypes={shipmentTypes} />
+      <ShipmentCreationGeneralComponent countries={countries} shipmentTypes={shipmentTypes} consignees={consignees} />
       <ShipmentCreationPackingListComponent startCollapsed={false} />
       <ShipmentCreationTrackingComponent startCollapsed={true} />
       {/* TODO can we make this HStack left aligned? */}

--- a/src/services/consignee-service.ts
+++ b/src/services/consignee-service.ts
@@ -1,0 +1,16 @@
+import { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import { DbConsignee } from '../types/aliases';
+import { Database } from '../types/database.types';
+
+export class ConsigneeService {
+  supabase: SupabaseClient<Database>;
+
+  constructor(supabase: SupabaseClient<Database>) {
+    this.supabase = supabase;
+  }
+
+  async fetchConsignees(onSuccess: (projects: DbConsignee[]) => void, onError: (error: PostgrestError) => void) {
+    const { data, error } = await this.supabase.from('consignee_partner').select('*');
+    return error ? onError(error) : onSuccess(data);
+  }
+}

--- a/src/services/country-service.ts
+++ b/src/services/country-service.ts
@@ -1,0 +1,16 @@
+import { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import { DbCountry } from '../types/aliases';
+import { Database } from '../types/database.types';
+
+export class CountryService {
+  supabase: SupabaseClient<Database>;
+
+  constructor(supabase: SupabaseClient<Database>) {
+    this.supabase = supabase;
+  }
+
+  async fetchCountries(onSuccess: (countries: DbCountry[]) => void, onError: (error: PostgrestError) => void) {
+    const { data, error } = await this.supabase.from('country').select('*');
+    return error ? onError(error) : onSuccess(data)
+  }
+}

--- a/src/services/donor-service.ts
+++ b/src/services/donor-service.ts
@@ -1,0 +1,16 @@
+import { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import { DbDonor } from '../types/aliases';
+import { Database } from '../types/database.types';
+
+export class DonorService {
+  supabase: SupabaseClient<Database>;
+
+  constructor(supabase: SupabaseClient<Database>) {
+    this.supabase = supabase;
+  }
+
+  async fetchDonors(onSuccess: (projects: DbDonor[]) => void, onError: (error: PostgrestError) => void) {
+    const { data, error } = await this.supabase.from('donor').select('*');
+    return error ? onError(error) : onSuccess(data)
+  }
+}

--- a/src/services/shipment-service.ts
+++ b/src/services/shipment-service.ts
@@ -1,5 +1,5 @@
 import { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
-import { DbShipment } from '../types/aliases';
+import { DbShipment, DbShipmentType } from '../types/aliases';
 import { Database } from '../types/database.types';
 
 export class ShipmentService {
@@ -12,6 +12,11 @@ export class ShipmentService {
   async fetchShipments(onSuccess: (projects: DbShipment[]) => void, onError: (error: PostgrestError) => void) {
     const { data, error } = await this.supabase.from('shipment').select('*');
     return error ? onError(error) : onSuccess(data);
+  }
+
+  async fetchShipmentTypes(onSuccess: (projects: DbShipmentType[]) => void, onError: (error: PostgrestError) => void) {
+    const { data, error } = await this.supabase.from('shipment_type').select('*');
+    return error ? onError(error) : onSuccess(data)
   }
 
   async create(shipment: DbShipment, onError: (error: PostgrestError) => void) {

--- a/src/services/shipment-service.ts
+++ b/src/services/shipment-service.ts
@@ -1,5 +1,5 @@
 import { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
-import { DbShipment, DbShipmentType } from '../types/aliases';
+import { DbShipment, DbShipmentStatus, DbShipmentType } from '../types/aliases';
 import { Database } from '../types/database.types';
 
 export class ShipmentService {
@@ -16,6 +16,11 @@ export class ShipmentService {
 
   async fetchShipmentTypes(onSuccess: (projects: DbShipmentType[]) => void, onError: (error: PostgrestError) => void) {
     const { data, error } = await this.supabase.from('shipment_type').select('*');
+    return error ? onError(error) : onSuccess(data)
+  }
+
+  async fetchShipmentStatuses(onSuccess: (projects: DbShipmentStatus[]) => void, onError: (error: PostgrestError) => void) {
+    const { data, error } = await this.supabase.from('shipment_status').select('*');
     return error ? onError(error) : onSuccess(data)
   }
 

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -5,3 +5,5 @@ export type DbCountry = Database['public']['Tables']['country']['Row']
 export type DbProject = Database['public']['Tables']['project']['Row']
 
 export type DbShipment = Database['public']['Tables']['shipment']['Row']
+
+export type DbShipmentType = Database['public']['Tables']['shipment_type']['Row']

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -1,5 +1,7 @@
 import { Database } from "./database.types";
 
+export type DbCountry = Database['public']['Tables']['country']['Row']
+
 export type DbProject = Database['public']['Tables']['project']['Row']
 
 export type DbShipment = Database['public']['Tables']['shipment']['Row']

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -7,3 +7,5 @@ export type DbProject = Database['public']['Tables']['project']['Row']
 export type DbShipment = Database['public']['Tables']['shipment']['Row']
 
 export type DbShipmentType = Database['public']['Tables']['shipment_type']['Row']
+
+export type DbConsignee = Database['public']['Tables']['consignee_partner']['Row']

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -8,4 +8,6 @@ export type DbShipment = Database['public']['Tables']['shipment']['Row']
 
 export type DbShipmentType = Database['public']['Tables']['shipment_type']['Row']
 
+export type DbShipmentStatus = Database['public']['Tables']['shipment_status']['Row']
+
 export type DbConsignee = Database['public']['Tables']['consignee_partner']['Row']

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -11,3 +11,5 @@ export type DbShipmentType = Database['public']['Tables']['shipment_type']['Row'
 export type DbShipmentStatus = Database['public']['Tables']['shipment_status']['Row']
 
 export type DbConsignee = Database['public']['Tables']['consignee_partner']['Row']
+
+export type DbDonor = Database['public']['Tables']['donor']['Row']

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -15,6 +15,14 @@ values
     ('complete');
 
 insert into
+    public.shipment_type (shipment_type)
+values
+    ('Shipping'),
+    ('Air Freight'),
+    ('Train'),
+    ('Truck');
+
+insert into
     public.country (code, name)
 values
     ('AF', 'Afghanistan'),

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -23,6 +23,11 @@ values
     ('Truck');
 
 insert into
+    public.consignee_partner (name)
+values
+    ('UHU / P22');
+
+insert into
     public.country (code, name)
 values
     ('AF', 'Afghanistan'),


### PR DESCRIPTION
### Changes

You can review commit-by-commit, but we now populate the:
- countries,
- shipment types,
- shipment statuses,
- donors, and
- consignees
from the DB. The values for these have been seeded directly.


https://github.com/Aid-Pioneers/shipment-aid-tracker/assets/1821099/2f62022b-0f87-40b7-bcde-aaf2099179bb



### Still to do
- Add a table for managing users properly so that we can populate the "managed by" field in the shipment form.
- Save the form and create the shipment