### PR TITLE
Redirect to the shipment view page when a shipment is created.

### DIFF
--- a/src/components/shipment/creation/general/index.tsx
+++ b/src/components/shipment/creation/general/index.tsx
@@ -8,6 +8,7 @@ import { DbConsignee, DbCountry, DbProfile, DbShipmentStatus, DbShipmentType } f
 import { Database } from '../../../../types/database.types';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
 import { SubmitPanel } from '../../common/submit-panel';
+import { useNavigate } from 'react-router-dom';
 
 interface GeneralComponentProps {
   startCollapsed?: boolean;
@@ -35,6 +36,8 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
   shipmentService,
 }) => {
   const [isCollapsed, setCollapsed] = useState<boolean | undefined>(startCollapsed);
+
+  const navigate = useNavigate();
 
   const countryOptions = countries.map((country) => (
     <option value={country.id} key={country.id}>
@@ -73,7 +76,11 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
         profile_id: undefined,
       };
 
-      await shipmentService.create(shipment, data.profile_id);
+      const shipmentId = await shipmentService.create(shipment, data.profile_id);
+
+      if (shipmentId !== undefined) {
+        navigate(`/shipments/${shipmentId}/`);
+      }
     } catch (error) {
       console.error('Error submitting form:', error);
     }
@@ -116,20 +123,20 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
                 {consigneeOptions}
               </Select>
             </GridItem>
-            {/* <GridItem colSpan={[6, 4]}>
+            <GridItem colSpan={[6, 4]}>
               <label>Internal ID</label>
-              <Input size="sm" id="internalId" {...register('internalId')} />
-            </GridItem> */}
+              <Input size="sm" id="internalId" />
+            </GridItem>
             <GridItem colSpan={[6, 4]}>
               <label>Managed By</label>
               <Select placeholder="Select option" {...register('profile_id')}>
                 {managerOptions}
               </Select>
             </GridItem>
-            {/* <GridItem colSpan={[6, 4]}>
+            <GridItem colSpan={[6, 4]}>
               <label>Drive Number:</label>
-              <Input size="sm" {...register('drive_number')} />
-            </GridItem> */}
+              <Input size="sm" />
+            </GridItem>
             <GridItem colSpan={[6, 8]}>
               <label>Drive Link</label>
               <Input size="sm" type="url" {...register('drive_link')} />

--- a/src/components/shipment/creation/general/types.ts
+++ b/src/components/shipment/creation/general/types.ts
@@ -1,5 +1,0 @@
-export interface CreateFormType {
-  origin: string;
-  destination: string;
-  shipmentType: string;
-}

--- a/src/components/shipment/creation/packing-list/index.tsx
+++ b/src/components/shipment/creation/packing-list/index.tsx
@@ -1,24 +1,49 @@
 import { Collapse, Grid, GridItem, Input, Select, Spacer } from '@chakra-ui/react';
 import * as React from 'react';
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { FormWrapper } from '../../../../containers/shipment/shipment-creation/index.styles';
 import { DbDonor } from '../../../../types/aliases';
 import { CollapsibleFormHeaderComponent } from '../../../collapsible-form-header';
+import { Database } from '../../../../types/database.types';
+import { ShipmentService } from '../../../../services/shipment-service';
+import { SubmitPanel } from '../../common/submit-panel';
 
 interface PackingListComponentProps {
-  startCollapsed?: boolean,
-  donors: DbDonor[]
+  startCollapsed?: boolean;
+  donors: DbDonor[];
+  shipmentService: ShipmentService;
 }
 
-export const ShipmentCreationPackingListComponent: React.FC<PackingListComponentProps> = ({ startCollapsed, donors }) => {
-  const { handleSubmit } = useForm<FormData>();
+type PackingShipmentForm = Database['public']['Tables']['shipment']['Update'];
+
+export const ShipmentCreationPackingListComponent: React.FC<PackingListComponentProps> = ({ startCollapsed, donors, shipmentService }) => {
+  const { register, handleSubmit } = useForm<PackingShipmentForm>();
 
   const [isCollapsed, setCollapsed] = useState<boolean | undefined>(startCollapsed);
 
-  const donorOptions = donors.map(donor => <option value={donor.id} key={donor.id}>{donor.name}</option>)
+  const donorOptions = donors.map((donor) => (
+    <option value={donor.id} key={donor.id}>
+      {donor.name}
+    </option>
+  ));
 
-  const onSubmit = () => { };
+  const onSubmit: SubmitHandler<PackingShipmentForm> = async (data: PackingShipmentForm) => {
+    try {
+      const shipment = {
+        ...data,
+      };
+
+      await shipmentService.update(shipment);
+    } catch (error) {
+      console.error('Error submitting form:', error);
+    }
+  };
+
+  const handleCancel = async () => {
+    // TODO https://github.com/Aid-Pioneers/shipment-aid-tracker/issues/53
+    // clear the form when the cancel action is taken
+  };
 
   return (
     <FormWrapper>
@@ -31,16 +56,16 @@ export const ShipmentCreationPackingListComponent: React.FC<PackingListComponent
               <Input size="sm" type="url" />
             </GridItem>
             <GridItem colSpan={[4, 3]}>
-              <Spacer>
-              </Spacer>
+              <Spacer></Spacer>
             </GridItem>
             <GridItem colSpan={[4, 4]}>
               <label>Donor</label>
-              <Select placeholder="Select option">
+              <Select placeholder="Select option" {...register('donor_id')}>
                 {donorOptions}
               </Select>
             </GridItem>
           </Grid>
+          <SubmitPanel onCancel={handleCancel} />
         </form>
       </Collapse>
     </FormWrapper>

--- a/src/containers/shipment/shipment-creation/index.tsx
+++ b/src/containers/shipment/shipment-creation/index.tsx
@@ -1,14 +1,12 @@
 import { Heading, VStack } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
 import { ShipmentCreationGeneralComponent } from '../../../components/shipment/creation/general';
-import { ShipmentCreationPackingListComponent } from '../../../components/shipment/creation/packing-list';
-import { ShipmentCreationTrackingComponent } from '../../../components/shipment/creation/tracking';
 import { ConsigneeService } from '../../../services/consignee-service';
 import { CountryService } from '../../../services/country-service';
 import { DonorService } from '../../../services/donor-service';
 import { ProfileService } from '../../../services/profile-service';
 import { ShipmentService } from '../../../services/shipment-service';
-import { DbConsignee, DbCountry, DbDonor, DbProfile, DbShipmentStatus, DbShipmentType } from '../../../types/aliases';
+import { DbConsignee, DbCountry, DbProfile, DbShipmentStatus, DbShipmentType } from '../../../types/aliases';
 interface ShipmentCreationContainerProps {
   shipmentService: ShipmentService;
   countryService: CountryService;
@@ -28,7 +26,6 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
   const [shipmentTypes, setShipmentTypes] = useState<DbShipmentType[]>([]);
   const [shipmentStatuses, setShipmentStatuses] = useState<DbShipmentStatus[]>([]);
   const [consignees, setConsignees] = useState<DbConsignee[]>([]);
-  const [donors, setDonors] = useState<DbDonor[]>([]);
   const [managers, setManagers] = useState<DbProfile[]>([]);
 
   useEffect(() => {
@@ -48,10 +45,6 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
         ),
         consigneeService.fetchConsignees(
           (data) => setConsignees(data),
-          (error) => console.error(error)
-        ),
-        donorService.fetchDonors(
-          (data) => setDonors(data),
           (error) => console.error(error)
         ),
         profileService.fetchProfiles(
@@ -78,8 +71,6 @@ export const ShipmentCreationContainer: React.FC<ShipmentCreationContainerProps>
         managers={managers}
         shipmentService={shipmentService}
       />
-      <ShipmentCreationPackingListComponent startCollapsed={false} donors={donors} />
-      <ShipmentCreationTrackingComponent startCollapsed={true} />
     </VStack>
   );
 };

--- a/src/services/shipment-service.ts
+++ b/src/services/shipment-service.ts
@@ -37,6 +37,12 @@ export class ShipmentService {
     return error ? onError(error) : onSuccess(data);
   }
 
+  async update(
+    shipment: Database["public"]["Tables"]["shipment"]["Update"],
+  ) {
+    this.supabase.from("shipment").update(shipment);
+  }
+
   async create(
     shipment: Database["public"]["Tables"]["shipment"]["Insert"],
     shipmentManager: Tables<"shipment_manager">["profile_id"],
@@ -60,6 +66,8 @@ export class ShipmentService {
           insertShipmentManager.error,
         );
       }
+
+      return maybeShipmentId;
     } else {
       console.error(`Failed to create shipment.`, insertShipmentResponse.error);
     }


### PR DESCRIPTION
There are a few IDs that don't link to a specific field in the DB. Either these form fields can be discarded or we need to update the DB. I don't know the answer to this, so let's leave them in the form for now, but let's not register their values when the form is submitted.