### PR TITLE
Store shipment manager ID in the shipment table, no need for separate table.

### DIFF
--- a/src/components/shipment/creation/general/index.tsx
+++ b/src/components/shipment/creation/general/index.tsx
@@ -22,10 +22,6 @@ interface GeneralComponentProps {
 
 type FormValuesShipment = Database['public']['Tables']['shipment']['Insert'];
 
-type FormValuesShipmentManager = Database['public']['Tables']['shipment_manager']['Insert'];
-
-type FormValuesGeneral = FormValuesShipment & FormValuesShipmentManager;
-
 export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> = ({
   startCollapsed,
   countries,
@@ -69,14 +65,14 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
     </option>
   ));
 
-  const onSubmit: SubmitHandler<FormValuesGeneral> = async (data: FormValuesGeneral) => {
+  const onSubmit: SubmitHandler<FormValuesShipment> = async (data: FormValuesShipment) => {
     try {
       const shipment = {
         ...data,
         profile_id: undefined,
       };
 
-      const shipmentId = await shipmentService.create(shipment, data.profile_id);
+      const shipmentId = await shipmentService.create(shipment);
 
       if (shipmentId !== undefined) {
         navigate(`/shipments/${shipmentId}/`);
@@ -91,7 +87,7 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
     // clear the form when the cancel action is taken
   };
 
-  const { register, handleSubmit } = useForm<FormValuesGeneral>();
+  const { register, handleSubmit } = useForm<FormValuesShipment>();
 
   return (
     <FormWrapper>
@@ -129,7 +125,7 @@ export const ShipmentCreationGeneralComponent: React.FC<GeneralComponentProps> =
             </GridItem>
             <GridItem colSpan={[6, 4]}>
               <label>Managed By</label>
-              <Select placeholder="Select option" {...register('profile_id')}>
+              <Select placeholder="Select option" {...register('manager_id')}>
                 {managerOptions}
               </Select>
             </GridItem>

--- a/src/services/shipment-service.ts
+++ b/src/services/shipment-service.ts
@@ -1,6 +1,6 @@
 import { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
 import { DbShipment, DbShipmentStatus, DbShipmentType } from "../types/aliases";
-import { Database, Tables } from "../types/database.types";
+import { Database } from "../types/database.types";
 
 export class ShipmentService {
   supabase: SupabaseClient<Database>;
@@ -45,31 +45,9 @@ export class ShipmentService {
 
   async create(
     shipment: Database["public"]["Tables"]["shipment"]["Insert"],
-    shipmentManager: Tables<"shipment_manager">["profile_id"],
   ) {
-    const insertShipmentResponse = await this.supabase.from("shipment").insert(
+    return this.supabase.from("shipment").insert(
       shipment,
     ).select("id").single();
-
-    const maybeShipmentId = insertShipmentResponse.data?.id;
-
-    if (maybeShipmentId !== undefined) {
-      const insertShipmentManager = await this.supabase.from("shipment_manager")
-        .insert({
-          profile_id: shipmentManager,
-          shipment_id: maybeShipmentId,
-        });
-
-      if (insertShipmentManager.error !== null) {
-        console.error(
-          `Failed to create shipment manager relationship with shipment ${maybeShipmentId}`,
-          insertShipmentManager.error,
-        );
-      }
-
-      return maybeShipmentId;
-    } else {
-      console.error(`Failed to create shipment.`, insertShipmentResponse.error);
-    }
   }
 }

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -249,6 +249,7 @@ export interface Database {
           impact_reporting: boolean | null
           logistics_expense_donation_usd: number | null
           main_shipment_type_id: number | null
+          manager_id: string | null
           origin_id: number
           patients_treated: number | null
           project_id: number | null
@@ -273,6 +274,7 @@ export interface Database {
           impact_reporting?: boolean | null
           logistics_expense_donation_usd?: number | null
           main_shipment_type_id?: number | null
+          manager_id?: string | null
           origin_id: number
           patients_treated?: number | null
           project_id?: number | null
@@ -297,6 +299,7 @@ export interface Database {
           impact_reporting?: boolean | null
           logistics_expense_donation_usd?: number | null
           main_shipment_type_id?: number | null
+          manager_id?: string | null
           origin_id?: number
           patients_treated?: number | null
           project_id?: number | null
@@ -334,6 +337,13 @@ export interface Database {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "shipment_manager_id_fkey"
+            columns: ["manager_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "shipment_origin_id_fkey"
             columns: ["origin_id"]
             isOneToOne: false
@@ -352,36 +362,6 @@ export interface Database {
             columns: ["status_id"]
             isOneToOne: false
             referencedRelation: "shipment_status"
-            referencedColumns: ["id"]
-          }
-        ]
-      }
-      shipment_manager: {
-        Row: {
-          profile_id: string
-          shipment_id: number
-        }
-        Insert: {
-          profile_id: string
-          shipment_id: number
-        }
-        Update: {
-          profile_id?: string
-          shipment_id?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "shipment_manager_profile_id_fkey"
-            columns: ["profile_id"]
-            isOneToOne: false
-            referencedRelation: "profile"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "shipment_manager_shipment_id_fkey"
-            columns: ["shipment_id"]
-            isOneToOne: false
-            referencedRelation: "shipment"
             referencedColumns: ["id"]
           }
         ]

--- a/supabase/migrations/20240424231315_simplify-shipment-managers.sql
+++ b/supabase/migrations/20240424231315_simplify-shipment-managers.sql
@@ -1,0 +1,64 @@
+drop policy "Enable all access for authenticated managers" on "public"."shipment_manager";
+
+drop policy "enable read for authenticated users only" on "public"."shipment_manager";
+
+revoke delete on table "public"."shipment_manager" from "anon";
+
+revoke insert on table "public"."shipment_manager" from "anon";
+
+revoke references on table "public"."shipment_manager" from "anon";
+
+revoke select on table "public"."shipment_manager" from "anon";
+
+revoke trigger on table "public"."shipment_manager" from "anon";
+
+revoke truncate on table "public"."shipment_manager" from "anon";
+
+revoke update on table "public"."shipment_manager" from "anon";
+
+revoke delete on table "public"."shipment_manager" from "authenticated";
+
+revoke insert on table "public"."shipment_manager" from "authenticated";
+
+revoke references on table "public"."shipment_manager" from "authenticated";
+
+revoke select on table "public"."shipment_manager" from "authenticated";
+
+revoke trigger on table "public"."shipment_manager" from "authenticated";
+
+revoke truncate on table "public"."shipment_manager" from "authenticated";
+
+revoke update on table "public"."shipment_manager" from "authenticated";
+
+revoke delete on table "public"."shipment_manager" from "service_role";
+
+revoke insert on table "public"."shipment_manager" from "service_role";
+
+revoke references on table "public"."shipment_manager" from "service_role";
+
+revoke select on table "public"."shipment_manager" from "service_role";
+
+revoke trigger on table "public"."shipment_manager" from "service_role";
+
+revoke truncate on table "public"."shipment_manager" from "service_role";
+
+revoke update on table "public"."shipment_manager" from "service_role";
+
+alter table "public"."shipment_manager" drop constraint "shipment_manager_profile_id_fkey";
+
+alter table "public"."shipment_manager" drop constraint "shipment_manager_shipment_id_fkey";
+
+alter table "public"."shipment_manager" drop constraint "shipment_manager_pkey";
+
+drop index if exists "public"."shipment_manager_pkey";
+
+drop table "public"."shipment_manager";
+
+alter table "public"."shipment" add column "manager_id" uuid;
+
+alter table "public"."shipment" add constraint "shipment_manager_id_fkey" FOREIGN KEY (manager_id) REFERENCES profile(id) not valid;
+
+alter table "public"."shipment" validate constraint "shipment_manager_id_fkey";
+
+
+


### PR DESCRIPTION
It's a minor thing, but it will make it easier to create new shipments as we only have to update one table. We also get no benefit from having them in two separate tables.